### PR TITLE
Prefix discord link with https://

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,7 @@ lang-ref: home
 | LECTURES    | Wednesday 9:30 – 11:30, Zoom |
 | PRACTICA    | Tuesdays 9:30 – 10:30, Zoom |
 | FORUM       | [r/NYU_DeepLearning](https://www.reddit.com/r/NYU_DeepLearning/) |
-| DISCORD     | [NYU DL](discord.gg/CthuqsX8Pb) |
+| DISCORD     | [NYU DL](https://discord.gg/CthuqsX8Pb) |
 | MATERIAL    | [2021 repo](https://github.com/Atcold/NYU-DLSP21) |
 
 


### PR DESCRIPTION
Otherwise the link on the website is not working as it resolves to `https://atcold.github.io/NYU-DLSP21/discord.gg/CthuqsX8Pb`