### PR TITLE
Visualise low-dimensional embeddings in spiral classification notebook

### DIFF
--- a/04-spiral_classification.ipynb
+++ b/04-spiral_classification.ipynb
@@ -24,7 +24,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from res.plot_lib import plot_data, plot_model, set_default, acc, overwrite, plot_2d_energy_levels, plot_3d_energy_levels"
+    "from res.plot_lib import plot_data, plot_model, plot_embeddings, set_default, acc, overwrite, plot_2d_energy_levels, plot_3d_energy_levels"
    ]
   },
   {
@@ -127,7 +127,8 @@
     "model = nn.Sequential(\n",
     "    nn.Linear(n, d),\n",
     "#     nn.ReLU(),  # Comment this line for a linear model\n",
-    "    nn.Linear(d, K)\n",
+    "    nn.Linear(d, K)  # (Optional) Comment this line and uncomment the next one to display 2D embeddings below\n",
+    "#     nn.Linear(d, 2), nn.Linear(2, K)\n",
     ")\n",
     "model.to(device)  # possibly send to CUDA\n",
     "\n",
@@ -138,7 +139,7 @@
     "optimiser = torch.optim.Adam(model.parameters(), lr=learning_rate, weight_decay=lambda_l2) # built-in L2\n",
     "\n",
     "# Full-batch training loop\n",
-    "for t in range(1_000):\n",
+    "for t in range(2_000):\n",
     "    \n",
     "    # Feed forward to get the logits\n",
     "    l = model(X)\n",
@@ -170,6 +171,16 @@
     "# Plot trained model\n",
     "print(model)\n",
     "plot_model(X, y, model)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# (Optional) Plot internal 2D embeddings if available\n",
+    "plot_embeddings(X, y, model, zoom=10)"
    ]
   },
   {

--- a/res/plot_lib.py
+++ b/res/plot_lib.py
@@ -13,7 +13,7 @@ def set_default(figsize=(10, 10), dpi=100):
     plt.rc('figure', figsize=figsize, dpi=dpi)
 
 
-def plot_data(X, y, d=0, auto=False, zoom=1):
+def plot_data(X, y, d=0, auto=False, zoom=1, title='Training data (x, y)'):
     X = X.cpu()
     y = y.cpu()
     s = plt.scatter(X.numpy()[:, 0], X.numpy()[:, 1], c=y, s=20, cmap=plt.cm.Spectral)
@@ -25,7 +25,7 @@ def plot_data(X, y, d=0, auto=False, zoom=1):
     _m, _c = 0, '.35'
     plt.axvline(0, ymin=_m, color=_c, lw=1)
     plt.axhline(0, xmin=_m, color=_c, lw=1)
-    plt.title('Training data (x, y)')
+    plt.title(title)
     return s
 
 


### PR DESCRIPTION
This PR adds simple code to visualise and play with 2D embeddings in the spiral classifcation notebook. 

Output example:

![Screenshot from 2022-05-15 10-39-56](https://user-images.githubusercontent.com/13064489/168466630-4ae12e28-a8a7-4f36-8f11-0ce9e62ed45e.png)
