### PR TITLE
Plot linear decision boundaries

### DIFF
--- a/res/plot_lib.py
+++ b/res/plot_lib.py
@@ -47,7 +47,7 @@ def plot_embeddings(X, y, model, zoom=10):
 
     def get_layer_outputs(name):
         def hook(model, input, output):
-            layer_outputs[name] = output.detach()
+            layer_outputs[name] = output
 
         return hook
 
@@ -55,7 +55,8 @@ def plot_embeddings(X, y, model, zoom=10):
 
     if layer.__class__ == torch.nn.modules.linear.Linear and layer.out_features == 2:
         layer.register_forward_hook(get_layer_outputs("low_dim_embeddings"))
-        model(X)  # pass data through model to populate layer_outputs
+        with torch.no_grad():
+            model(X)  # pass data through model to populate layer_outputs
         plot_data(
             layer_outputs["low_dim_embeddings"],
             y,

--- a/res/plot_lib.py
+++ b/res/plot_lib.py
@@ -1,9 +1,8 @@
-from matplotlib import pyplot as plt
+import matplotlib as mpl
 import numpy as np
 import torch
-from IPython.display import HTML, display, clear_output
-import matplotlib as mpl
-from mpl_toolkits import mplot3d
+from IPython.display import clear_output
+from matplotlib import pyplot as plt
 
 
 def set_default(figsize=(10, 10), dpi=100):

--- a/res/plot_lib.py
+++ b/res/plot_lib.py
@@ -63,6 +63,14 @@ def plot_embeddings(X, y, model, zoom=10):
             zoom=zoom,
             title="Low dim embeddings",
         )
+        last_layer = model[-1]
+        mesh = torch.arange(-1.1, 1.1, 0.01) * zoom
+        xx, yy = torch.meshgrid(mesh, mesh, indexing="ij")
+        with torch.no_grad():
+            data = torch.stack((xx.reshape(-1), yy.reshape(-1)), dim=1)
+            Z = last_layer(data)
+        Z = Z.argmax(dim=1).reshape(xx.shape)
+        plt.contourf(xx, yy, Z, cmap=plt.cm.Spectral, alpha=0.3, levels=y.max().item())
     else:
         print(
             "Cannot plot: second-last layer is not a linear layer"


### PR DESCRIPTION
### Code changes
* Plots the linear decision boundaries on top of low dim embeddings (all credits to @Atcold: see [here](https://github.com/Atcold/NYU-DLSP21/pull/32#issuecomment-1149411240) and [there](https://github.com/Atcold/NYU-DLSP21/pull/32#issuecomment-1149421739))
* Minor code cleaning

### Test
Local test in jupyter lab:
![image](https://user-images.githubusercontent.com/13064489/172704731-67136b55-c404-4276-a6f8-669b7f5dafe7.png)