### PR TITLE
Link correction

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ We've treated LV-EBM as a *basic* module, which to build upon.
 
 ## Enters the semester's second half
 
-I thought I was going to repropose the same practica I've used during [NYU-DLSP20](https://github.com/Atcold/pytorch-Deep-Learning), last year edition, just in different order.
+I thought I was going to repropose the same practica I've used during [NYU-DLSP20](https://github.com/Atcold/NYU-DLSP20), last year edition, just in different order.
 
 But I couldn't.
 
@@ -43,7 +43,7 @@ A more powerful one.
 
 Before NYU-DLSP21 there were…
 
-- [NYU-DLSP20](https://github.com/Atcold/pytorch-Deep-Learning) (major release)
+- [NYU-DLSP20](https://github.com/Atcold/NYU-DLSP20) (major release)
 - [NYU-DLSP19](https://github.com/Atcold/pytorch-Deep-Learning/releases/tag/dlsp19)
 - [AIMS-DLFL19](https://github.com/Atcold/pytorch-Deep-Learning/releases/tag/aims-fl18)
 - [CoDaS-HEP18](https://github.com/Atcold/pytorch-Deep-Learning/releases/tag/v1.0.0)

--- a/docs/en/week01/01.md
+++ b/docs/en/week01/01.md
@@ -6,9 +6,9 @@ title: Week 1
 
 ## Lecture
 
-Some history can be found [here](https://atcold.github.io/pytorch-Deep-Learning/en/week01/01-1/), while gradient descent can be found [here](https://atcold.github.io/pytorch-Deep-Learning/en/week02/02-1/).
+Some history can be found [here](https://atcold.github.io/NYU-DLSP20/en/week01/01-1/), while gradient descent can be found [here](https://atcold.github.io/NYU-DLSP20/en/week02/02-1/).
 
 
 ## Practicum
 
-This plus the next practicum's summary can be found [here](https://atcold.github.io/pytorch-Deep-Learning/en/week01/01-3/).
+This plus the next practicum's summary can be found [here](https://atcold.github.io/NYU-DLSP20/en/week01/01-3/).

--- a/docs/en/week02/02-3.md
+++ b/docs/en/week02/02-3.md
@@ -45,4 +45,4 @@ In order to effectively separate these images, we consider ways of transforming 
 
 Note that translation alone is not linear since 0 will not always be mapped to 0, but it is an affine transformation. Returning to our image example, we can transform the data points by translating such that the points are clustered around 0 and scaling with a diagonal matrix such that we "zoom in" to that region. Finally, we can do classification by finding lines across the space which separate the different points into their respective classes. In other words, the idea is to use linear and nonlinear transformations to map the points into a space such that they are linearly separable. This idea will be made more concrete in the following sections.
 
-In the next part, we visualize how a neural network separates points and a few linear and non-linear transformations. This can be accessed [here](https://atcold.github.io/pytorch-Deep-Learning/en/week01/01-3/).
+In the next part, we visualize how a neural network separates points and a few linear and non-linear transformations. This can be accessed [here](https://atcold.github.io/NYU-DLSP20/en/week01/01-3/).

--- a/docs/en/week02/02.md
+++ b/docs/en/week02/02.md
@@ -6,7 +6,7 @@ title: Week 2
 
 ## Lecture
 
-Similar to [this](https://atcold.github.io/pytorch-Deep-Learning/en/week11/11-1/), [this](https://atcold.github.io/pytorch-Deep-Learning/en/week11/11-2/), and possibly more.
+Similar to [this](https://atcold.github.io/NYU-DLSP20/en/week11/11-1/), [this](https://atcold.github.io/NYU-DLSP20/en/week11/11-2/), and possibly more.
 
 
 ## Practicum

--- a/docs/en/week03/03-3.md
+++ b/docs/en/week03/03-3.md
@@ -58,4 +58,4 @@ Usually, we use backpropagation to compute the gradient, then we apply gradient 
 
 
 ## Spiral Classification
-The following content is mostly the same, so [here](https://atcold.github.io/pytorch-Deep-Learning/en/week02/02-3/) you can find what you need.
+The following content is mostly the same, so [here](https://atcold.github.io/NYU-DLSP20/en/week02/02-3/) you can find what you need.

--- a/docs/en/week03/03.md
+++ b/docs/en/week03/03.md
@@ -6,7 +6,7 @@ title: Week 3
 
 ## Lecture
 
-Parts can be found [here](https://atcold.github.io/pytorch-Deep-Learning/en/week03/03-1/) and part [here](https://atcold.github.io/pytorch-Deep-Learning/en/week06/06-2/).
+Parts can be found [here](https://atcold.github.io/NYU-DLSP20/en/week03/03-1/) and part [here](https://atcold.github.io/NYU-DLSP20/en/week06/06-2/).
 
 
 ## Practicum

--- a/docs/en/week04/04.md
+++ b/docs/en/week04/04.md
@@ -6,8 +6,8 @@ title: Week 4
 
 ## Lecture
 
-Similar to [last year's edition](https://atcold.github.io/pytorch-Deep-Learning/en/week06/06-1/).
+Similar to [last year's edition](https://atcold.github.io/NYU-DLSP20/en/week06/06-1/).
 
 ## Practicum A & B
 
-Similar to last year's edition of [CNN](https://atcold.github.io/pytorch-Deep-Learning/en/week03/03-3/) and [RNN](https://atcold.github.io/pytorch-Deep-Learning/en/week06/06-3/).
+Similar to last year's edition of [CNN](https://atcold.github.io/NYU-DLSP20/en/week03/03-3/) and [RNN](https://atcold.github.io/NYU-DLSP20/en/week06/06-3/).

--- a/docs/en/week05/05.md
+++ b/docs/en/week05/05.md
@@ -6,8 +6,8 @@ title: Week 5
 
 ## Lecture
 
-Similar to [last year's](https://atcold.github.io/pytorch-Deep-Learning/en/week07/07-1/) but different.
+Similar to [last year's](https://atcold.github.io/NYU-DLSP20/en/week07/07-1/) but different.
 
 ## Practicum
 
-Same as [last year](https://atcold.github.io/pytorch-Deep-Learning/en/week15/15-1/).
+Same as [last year](https://atcold.github.io/NYU-DLSP20/en/week15/15-1/).

--- a/docs/en/week06/06.md
+++ b/docs/en/week06/06.md
@@ -6,8 +6,8 @@ title: Week 6
 
 ## Lecture
 
-Similar to [this](https://atcold.github.io/pytorch-Deep-Learning/en/week14/14-1/) and [this](https://atcold.github.io/pytorch-Deep-Learning/en/week14/14-2/).
+Similar to [this](https://atcold.github.io/NYU-DLSP20/en/week14/14-1/) and [this](https://atcold.github.io/NYU-DLSP20/en/week14/14-2/).
 
 ## Practicum
 
-Same as [last year](https://atcold.github.io/pytorch-Deep-Learning/en/week15/15-2/).
+Same as [last year](https://atcold.github.io/NYU-DLSP20/en/week15/15-2/).

--- a/docs/en/week10/10-3.md
+++ b/docs/en/week10/10-3.md
@@ -57,7 +57,7 @@ In a transformer, $\vy$ (target sentence) is a discrete time signal. It has disc
 The observed signal, $\vx$ (source sentence) , is also fed through an encoder. The output of both encoder and delayed encoder are fed into the predictor, which gives a hidden representation $\vh$. This is very similar to denoising autoencoder as the delay module acts as noise in this case. And $\vx$ here makes this entire architecture a conditional delayed denoising autoencoder.
 
 ### Encoder module
-You can see the detailed explanation of these modules from last year's slides [here](https://atcold.github.io/pytorch-Deep-Learning/en/week12/12-3/).
+You can see the detailed explanation of these modules from last year's slides [here](https://atcold.github.io/NYU-DLSP20/en/week12/12-3/).
 
 
 ### Predictor Module
@@ -71,7 +71,7 @@ The transformer predictor module follows a similar procedure as the encoder. How
 </center>
 
 ### Cross attention
-You can see the detailed explanation of cross attention from last year's slides [cross-attention](https://atcold.github.io/pytorch-Deep-Learning/en/week12/12-3/).
+You can see the detailed explanation of cross attention from last year's slides [cross-attention](https://atcold.github.io/NYU-DLSP20/en/week12/12-3/).
 
 
 ### Decoder module

--- a/docs/fr/README-FR.md
+++ b/docs/fr/README-FR.md
@@ -51,7 +51,7 @@ Henceforth, I've redesigned my whole deck of slides.
 
 ## La seconde moitié du semestre
 
-Alfredo pensait reproduire les mêmes travaux pratiques utilisés pour l'édition de l'année dernière, [NYU-DLSP20](https://github.com/Atcold/pytorch-Deep-Learning), mais dans un ordre différent.  
+Alfredo pensait reproduire les mêmes travaux pratiques utilisés pour l'édition de l'année dernière, [NYU-DLSP20](https://github.com/Atcold/NYU-DLSP20), mais dans un ordre différent.  
 
 Cependant il n'a pas pu.  
 
@@ -98,7 +98,7 @@ Before NYU-DLSP21 there were…
 
 Avant NYU-DLSP21, il y a eu :
 
-- [NYU-DLSP20](https://github.com/Atcold/pytorch-Deep-Learning) (version la plus importante)
+- [NYU-DLSP20](https://github.com/Atcold/NYU-DLSP20) (version la plus importante)
 - [NYU-DLSP19](https://github.com/Atcold/pytorch-Deep-Learning/releases/tag/dlsp19)
 - [AIMS-DLFL19](https://github.com/Atcold/pytorch-Deep-Learning/releases/tag/aims-fl18)
 - [CoDaS-HEP18](https://github.com/Atcold/pytorch-Deep-Learning/releases/tag/v1.0.0)

--- a/docs/fr/week01/01.md
+++ b/docs/fr/week01/01.md
@@ -12,7 +12,7 @@ translator: Loïck Bourdois
 Some history can be found [here](https://atcold.github.io/pytorch-Deep-Learning/en/week01/01-1/), while gradient descent can be found [here](https://atcold.github.io/pytorch-Deep-Learning/en/week02/02-1/).
 -->
 ## Cours magistral
-Un peu d'histoire sur l'apprentissage supervisé peut être trouvée [ici](https://atcold.github.io/pytorch-Deep-Learning/fr/week01/01-1/), tandis que la descente de gradient peut être trouvée [ici](https://atcold.github.io/pytorch-Deep-Learning/fr/week02/02-1/).
+Un peu d'histoire sur l'apprentissage supervisé peut être trouvée [ici](https://atcold.github.io/NYU-DLSP20/fr/week01/01-1/), tandis que la descente de gradient peut être trouvée [ici](https://atcold.github.io/NYU-DLSP20/fr/week02/02-1/).
 
 <!--
 ## Practicum
@@ -20,4 +20,4 @@ Un peu d'histoire sur l'apprentissage supervisé peut être trouvée [ici](https
 This plus the next practicum's summary can be found [here](https://atcold.github.io/pytorch-Deep-Learning/en/week01/01-3/).
 -->
 ## Travaux dirigés
-Le résumé de cette semaine et de la suivante peuvent être trouvé [ici](https://atcold.github.io/pytorch-Deep-Learning/fr/week01/01-3/).
+Le résumé de cette semaine et de la suivante peuvent être trouvé [ici](https://atcold.github.io/NYU-DLSP20/fr/week01/01-3/).

--- a/docs/fr/week02/02-3.md
+++ b/docs/fr/week02/02-3.md
@@ -109,4 +109,4 @@ En d'autres termes, l'idée est d'utiliser des transformations linéaires et non
 Cette idée sera rendue plus concrète dans les sections suivantes.
 
 Dans la suite, nous visualisons comment un réseau neuronal sépare des points et quelques transformations linéaires et non linéaires. 
-Ce contenu est essentiellement le même que celui de l'année dernière, ainsi nous vous invitons à vous rendre [ici](https://atcold.github.io/pytorch-Deep-Learning/fr/week01/01-3/) pour le consulter.
+Ce contenu est essentiellement le même que celui de l'année dernière, ainsi nous vous invitons à vous rendre [ici](https://atcold.github.io/NYU-DLSP20/fr/week01/01-3/) pour le consulter.

--- a/docs/fr/week02/02.md
+++ b/docs/fr/week02/02.md
@@ -13,7 +13,7 @@ Similar to [this](https://atcold.github.io/pytorch-Deep-Learning/en/week11/11-1/
 -->
 
 ## Cours magistral 
-Similaire à [ceci](https://atcold.github.io/pytorch-Deep-Learning/fr/week11/11-1/) et [ceci](https://atcold.github.io/pytorch-Deep-Learning/fr/week11/11-2/) et peut-être plus.
+Similaire à [ceci](https://atcold.github.io/NYU-DLSP20/fr/week11/11-1/) et [ceci](https://atcold.github.io/NYU-DLSP20/fr/week11/11-2/) et peut-être plus.
 
 
 <!--

--- a/docs/fr/week03/03-3.md
+++ b/docs/fr/week03/03-3.md
@@ -111,4 +111,4 @@ Cet exemple montre que la rétropropagation n'est PAS uniquement utilisée penda
 The following content is mostly the same, so [here](https://atcold.github.io/pytorch-Deep-Learning/en/week02/02-3/) you can find what you need.
 -->
 ## Classification d'une spirale
-Le contenu suivant est essentiellement le même que celui de l'année dernière, rendez-vous donc [ici](https://atcold.github.io/pytorch-Deep-Learning/fr/week02/02-3/) pour le consulter.
+Le contenu suivant est essentiellement le même que celui de l'année dernière, rendez-vous donc [ici](https://atcold.github.io/NYU-DLSP20/fr/week02/02-3/) pour le consulter.

--- a/docs/fr/week03/03.md
+++ b/docs/fr/week03/03.md
@@ -13,7 +13,7 @@ translator: Loïck Bourdois
 Parts can be found [here](https://atcold.github.io/pytorch-Deep-Learning/en/week03/03-1/) and part [here](https://atcold.github.io/pytorch-Deep-Learning/en/week06/06-2/).
 -->
 ## Cours magistral
-Les différentes parties peuvent être trouvées [ici](https://atcold.github.io/pytorch-Deep-Learning/fr/week03/03-1/) et [ici](https://atcold.github.io/pytorch-Deep-Learning/fr/week06/06-2/).
+Les différentes parties peuvent être trouvées [ici](https://atcold.github.io/NYU-DLSP20/fr/week03/03-1/) et [ici](https://atcold.github.io/NYU-DLSP20/fr/week06/06-2/).
 
 
 <!--

--- a/docs/fr/week04/04.md
+++ b/docs/fr/week04/04.md
@@ -12,7 +12,7 @@ translator: Loïck Bourdois
 Similar to [last year's edition](https://atcold.github.io/pytorch-Deep-Learning/en/week06/06-1/).
 -->
 ## Cours magistral
-Similaire à [l'édition de l'année dernière](https://atcold.github.io/pytorch-Deep-Learning/fr/week06/06-1/).
+Similaire à [l'édition de l'année dernière](https://atcold.github.io/NYU-DLSP20/fr/week06/06-1/).
 
 
 <!--
@@ -21,4 +21,4 @@ Similaire à [l'édition de l'année dernière](https://atcold.github.io/pytorch
 Similar to last year's edition of [CNN](https://atcold.github.io/pytorch-Deep-Learning/en/week03/03-3/) and [RNN](https://atcold.github.io/pytorch-Deep-Learning/en/week06/06-3/).
 -->
 ## Travaux dirigés A & B
-Similaires à l'édition de l'année dernière : pour les [ConvNets](https://atcold.github.io/pytorch-Deep-Learning/fr/week03/03-3/), pour les [RNNs](https://atcold.github.io/pytorch-Deep-Learning/fr/week06/06-3/).
+Similaires à l'édition de l'année dernière : pour les [ConvNets](https://atcold.github.io/NYU-DLSP20/fr/week03/03-3/), pour les [RNNs](https://atcold.github.io/NYU-DLSP20/fr/week06/06-3/).

--- a/docs/fr/week05/05.md
+++ b/docs/fr/week05/05.md
@@ -12,7 +12,7 @@ translator: Loïck Bourdois
 Similar to [last year's](https://atcold.github.io/pytorch-Deep-Learning/en/week07/07-1/) but different.
 -->
 ## Cours magistral
-Similaire à [celui de l'année dernière](https://atcold.github.io/pytorch-Deep-Learning/fr/week07/07-1/) mais un peu différent.
+Similaire à [celui de l'année dernière](https://atcold.github.io/NYU-DLSP20/fr/week07/07-1/) mais un peu différent.
 
 
 <!--
@@ -21,4 +21,4 @@ Similaire à [celui de l'année dernière](https://atcold.github.io/pytorch-Deep
 Same as [last year](https://atcold.github.io/pytorch-Deep-Learning/en/week15/15-1/).
 -->
 ## Travaux dirigés
-Comme [l'année dernière](https://atcold.github.io/pytorch-Deep-Learning/fr/week15/15-1/).
+Comme [l'année dernière](https://atcold.github.io/NYU-DLSP20/fr/week15/15-1/).

--- a/docs/fr/week06/06.md
+++ b/docs/fr/week06/06.md
@@ -13,7 +13,7 @@ translator: Loïck Bourdois
 Similar to [this](https://atcold.github.io/pytorch-Deep-Learning/en/week14/14-1/) and [this](https://atcold.github.io/pytorch-Deep-Learning/en/week14/14-2/).
 -->
 ## Cours magistral
-Similaire à [ceci](https://atcold.github.io/pytorch-Deep-Learning/fr/week14/14-1/) et [ceci](https://atcold.github.io/pytorch-Deep-Learning/fr/week14/14-2/).
+Similaire à [ceci](https://atcold.github.io/NYU-DLSP20/fr/week14/14-1/) et [ceci](https://atcold.github.io/NYU-DLSP20/fr/week14/14-2/).
 
 <!--
 ## Practicum
@@ -21,4 +21,4 @@ Similaire à [ceci](https://atcold.github.io/pytorch-Deep-Learning/fr/week14/14-
 Same as [last year](https://atcold.github.io/pytorch-Deep-Learning/en/week15/15-2/).
 -->
 ## Travaux dirigés
-Comme [l'année dernière](https://atcold.github.io/pytorch-Deep-Learning/fr/week15/15-2/).
+Comme [l'année dernière](https://atcold.github.io/NYU-DLSP20/fr/week15/15-2/).

--- a/docs/fr/week10/10-3.md
+++ b/docs/fr/week10/10-3.md
@@ -124,7 +124,7 @@ You can see the detailed explaination of these modules from last year's slides [
 -->
 
 ### Module encodeur
-Vous pouvez voir l'explication détaillée de ce module dans les notes de l'année dernière disponibles [ici](https://atcold.github.io/pytorch-Deep-Learning/fr/week12/12-3/).
+Vous pouvez voir l'explication détaillée de ce module dans les notes de l'année dernière disponibles [ici](https://atcold.github.io/NYU-DLSP20/fr/week12/12-3/).
 
 
 <!--
@@ -158,7 +158,7 @@ You can see the detailed explaination of cross attention from last year's slides
 -->
 
 ### Attention croisée
-Vous pouvez consulter l'explication détaillée de l'attention croisée dans les notes de l'année dernière disponibles [ici](https://atcold.github.io/pytorch-Deep-Learning/fr/week12/12-3/).
+Vous pouvez consulter l'explication détaillée de l'attention croisée dans les notes de l'année dernière disponibles [ici](https://atcold.github.io/NYU-DLSP20/fr/week12/12-3/).
 
 <!--
 ### Decoder module


### PR DESCRIPTION
Hi @Atcold 

I've corrected all (I hope I didn't forget any) links pointing to the 2020 edition, i.e. I've changed https://atcold.github.io/pytorch-Deep-Learning to https://atcold.github.io/NYU-DLSP20